### PR TITLE
fix: making lambda correctly return 500 errors

### DIFF
--- a/src/aws/osml/data_intake/processor_base.py
+++ b/src/aws/osml/data_intake/processor_base.py
@@ -30,7 +30,7 @@ class ProcessorBase(ABC):
         Returns an error message in the form of a dictionary, including a stack trace, intended for an HTTP response.
 
         :param e: The exception that triggered the failure.
-        :returns: A dictionary with 'statusCode' set to 400 and a 'body' containing the error message and stack trace.
+        :returns: A dictionary with 'statusCode' set to 500 and a 'body' containing the error message and stack trace.
         """
         # Log the error and stack trace
         stack_trace = traceback.format_exc()
@@ -38,7 +38,7 @@ class ProcessorBase(ABC):
 
         # Return the error message and stack trace in the response
         error_response = {"message": str(e), "stack_trace": stack_trace.splitlines()}
-        return {"statusCode": 400, "body": json.dumps(error_response)}
+        return {"statusCode": 500, "body": json.dumps(error_response)}
 
     @abstractmethod
     def process(self) -> Dict[str, Any]:

--- a/test/aws/osml/data_intake/test_image_processor.py
+++ b/test/aws/osml/data_intake/test_image_processor.py
@@ -72,7 +72,7 @@ class TestImageProcessor(unittest.TestCase):
         response = self.processor.process()
 
         # Check the response
-        self.assertEqual(response["statusCode"], 400)
+        self.assertEqual(response["statusCode"], 500)
         self.assertIn("Unable to Load", response["body"])
 
 

--- a/test/aws/osml/data_intake/test_ingest_processor.py
+++ b/test/aws/osml/data_intake/test_ingest_processor.py
@@ -92,7 +92,7 @@ class TestIngestProcessor(unittest.TestCase):
         event = self.sns_event()
         response = handler(event, None)
 
-        self.assertEqual(response["statusCode"], 400)
+        self.assertEqual(response["statusCode"], 500)
         self.assertIn("Database error", json.loads(response["body"])["message"])
 
 

--- a/test/aws/osml/data_intake/test_processor_base.py
+++ b/test/aws/osml/data_intake/test_processor_base.py
@@ -25,7 +25,7 @@ class TestProcessorBase(unittest.TestCase):
 
         result_body = json.loads(result["body"])
 
-        self.assertEqual(result["statusCode"], 400)
+        self.assertEqual(result["statusCode"], 500)
         self.assertIn("message", result_body)
         self.assertIn("stack_trace", result_body)
         self.assertEqual(result_body["message"], exception_message)


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes
Updating the ``BaseProcessor`` class to correctly return 500 values when the function fails.

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
