### PR TITLE
fix: allow ingest without ovr file and minor logging updates

### DIFF
--- a/src/aws/osml/data_intake/bulk_processor.py
+++ b/src/aws/osml/data_intake/bulk_processor.py
@@ -61,7 +61,7 @@ class BulkProcessor:
         :return Tuple containing ImageData and S3Manager instance.
         """
 
-        AsyncContextFilter.set_context({"image_hash": image_id})
+        AsyncContextFilter.set_context({"item_id": image_id})
 
         s3_url = S3Url(image)
         s3_manager = S3Manager(self.output_bucket, self.aws_s3, f"{self.input_path}/{image_id}")

--- a/src/aws/osml/data_intake/ingest_processor.py
+++ b/src/aws/osml/data_intake/ingest_processor.py
@@ -10,7 +10,7 @@ from stac_fastapi.types.stac import Collection, Item
 
 from .managers import SNSManager
 from .processor_base import ProcessorBase
-from .utils import ServiceConfig, get_minimal_collection_dict, logger
+from .utils import AsyncContextFilter, ServiceConfig, get_minimal_collection_dict, logger
 
 
 class IngestProcessor(ProcessorBase):
@@ -41,8 +41,9 @@ class IngestProcessor(ProcessorBase):
         try:
             # Here we assume 'item' includes necessary fields like 'id'
             item_id = self.stac_item["id"]
+            AsyncContextFilter.set_context({"item_id": item_id})
             collection_id = self.stac_item["collection"]
-            logger.info(f"Creating STAC item with ID {item_id} in collection {collection_id}.")
+            logger.info(f"Creating STAC item in collection {collection_id}.")
 
             # Create a STAC item in the open search database.
             #  If the item collection does not exist, create a minimal one and then insert the item.

--- a/src/aws/osml/data_intake/utils/logger.py
+++ b/src/aws/osml/data_intake/utils/logger.py
@@ -98,8 +98,8 @@ def get_logger(name: str = __name__, level: int = logging.INFO) -> logging.Logge
     return lambda_logger
 
 
-formatter = JsonFormatter(fmt="%(asctime)s %(name)s %(levelname)s %(image_hash)s %(message)s", datefmt="%Y-%m-%dT%H:%M:%S")
+formatter = JsonFormatter(fmt="%(asctime)s %(name)s %(levelname)s %(item_id)s %(message)s", datefmt="%Y-%m-%dT%H:%M:%S")
 
-filter = AsyncContextFilter(attribute_names=["image_hash"])
+filter = AsyncContextFilter(attribute_names=["item_id"])
 
 logger = configure_logger(logger=get_logger(), log_level=logging.INFO, log_formatter=formatter, log_filter=filter)


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes
GDAL does not generate overviews in cases where a small image is ingested.  This updates Data Intake to conditionally include the ovr file since a stac item is still valid without an overview.

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
