### PR TITLE
fix: set collection index mapping

### DIFF
--- a/docker/Dockerfile.stac
+++ b/docker/Dockerfile.stac
@@ -1,13 +1,14 @@
-# Copyright 2024 Amazon.com, Inc. or its affiliates.
+# Copyright 2024-2025 Amazon.com, Inc. or its affiliates.
 
-FROM public.ecr.aws/lambda/python:3.11 as stac
+FROM public.ecr.aws/lambda/python:3.13 AS stac
 
-RUN yum -y upgrade && \
-    yum -y install gcc ca-certificates && \
-    yum clean all && \
-    rm -rf /var/cache/yum
+RUN dnf -y upgrade && \
+    dnf -y install gcc ca-certificates && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf
 
-RUN pip3 install --no-cache-dir stac_fastapi.core stac_fastapi.opensearch[server] stac_fastapi.types mangum
+COPY docker/requirements-stac.txt ./requirements.txt
+RUN pip3 install --no-cache-dir -r requirements.txt
 
 EXPOSE 8080
 

--- a/docker/requirements-stac.txt
+++ b/docker/requirements-stac.txt
@@ -1,0 +1,5 @@
+# Copyright 2025 Amazon.com, Inc. or its affiliates.
+stac-fastapi-core==6.3.0
+stac-fastapi-opensearch==6.3.0
+stac-fastapi-types==6.0.0
+mangum==0.19.0

--- a/src/aws/osml/data_intake/ingest_processor.py
+++ b/src/aws/osml/data_intake/ingest_processor.py
@@ -4,7 +4,7 @@ import asyncio
 import json
 from typing import Any, Dict
 
-from stac_fastapi.opensearch.database_logic import DatabaseLogic
+from stac_fastapi.opensearch.database_logic import DatabaseLogic, create_collection_index
 from stac_fastapi.types.errors import NotFoundError
 from stac_fastapi.types.stac import Collection, Item
 
@@ -69,6 +69,9 @@ class IngestProcessor(ProcessorBase):
             return self.failure_message(error)
 
     async def create_minimal_collection(self, collection_id: str) -> None:
+        # Ensure proper collection index exists with correct mapping (idempotent)
+        await create_collection_index()
+        # Create collection
         collection = Collection(**get_minimal_collection_dict(collection_id))
         await self.database.create_collection(collection)
 


### PR DESCRIPTION
### Notes
This fix updates the ingest processor to create the collection index before creating a collection.  This prevents the default OpenSearch mapping from being applied incorrectly to the collection index when the new collection being created is the first one in the OpenSearch cluster.
Additionally, this fix pins the versions of stac-fastapi components used in the Dockerfile.

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
