### PR TITLE
test: Convert all unit tests to use pytest

### DIFF
--- a/test/aws/osml/data_intake/conftest.py
+++ b/test/aws/osml/data_intake/conftest.py
@@ -1,0 +1,41 @@
+#  Copyright 2024-2026 Amazon.com, Inc. or its affiliates.
+
+import boto3
+import pytest
+from moto import mock_aws
+
+
+@pytest.fixture
+def mock_s3():
+    """Mocked S3 resource with a test bucket."""
+    with mock_aws():
+        s3 = boto3.resource("s3", region_name="us-east-1")
+        s3.meta.client.create_bucket(Bucket="test-bucket")
+        yield s3
+
+
+@pytest.fixture
+def mock_sns():
+    """Mocked SNS client with a test topic."""
+    with mock_aws():
+        sns = boto3.client("sns", region_name="us-east-1")
+        response = sns.create_topic(Name="test-topic")
+        yield sns, response["TopicArn"]
+
+
+@pytest.fixture
+def mock_aws_services():
+    """Combined S3 + SNS mock environment (single mock_aws context)."""
+    with mock_aws():
+        s3 = boto3.resource("s3", region_name="us-east-1")
+        s3.meta.client.create_bucket(Bucket="test-bucket")
+
+        sns = boto3.client("sns", region_name="us-east-1")
+        response = sns.create_topic(Name="test-topic")
+
+        yield {
+            "s3": s3,
+            "sns": sns,
+            "sns_topic_arn": response["TopicArn"],
+            "test_bucket": "test-bucket",
+        }

--- a/test/aws/osml/data_intake/managers/test_s3_manager.py
+++ b/test/aws/osml/data_intake/managers/test_s3_manager.py
@@ -1,20 +1,18 @@
-# Copyright 2024 Amazon.com, Inc. or its affiliates.
+# Copyright 2024-2026 Amazon.com, Inc. or its affiliates.
 
-import unittest
 from unittest.mock import patch
 
 import boto3
+import pytest
 from boto3.exceptions import S3UploadFailedError
 from botocore.exceptions import ClientError
 from moto import mock_aws
 
+from aws.osml.data_intake.managers.s3_manager import S3Manager, S3Url
 
-class TestS3Url(unittest.TestCase):
-    """
-    A test suite for the S3Url class in the AWS OSML data intake module.
 
-    Tests the initialization of the S3Url class to ensure that S3 URLs are parsed correctly.
-    """
+class TestS3Url:
+    """A test suite for the S3Url class in the AWS OSML data intake module."""
 
     def test_initialization(self):
         """
@@ -22,111 +20,100 @@ class TestS3Url(unittest.TestCase):
 
         Asserts that the bucket name, key, and full URL are correctly extracted from an S3 URL.
         """
-        from aws.osml.data_intake.managers.s3_manager import S3Url
-
         url = "s3://bucketname/example/object.txt"
         s3_url = S3Url(url)
-        self.assertEqual(s3_url.bucket, "bucketname")
-        self.assertEqual(s3_url.key, "example/object.txt")
-        self.assertEqual(s3_url.url, url)
-        self.assertEqual(s3_url.prefix, "example")
-        self.assertEqual(s3_url.filename, "object.txt")
+        assert s3_url.bucket == "bucketname"
+        assert s3_url.key == "example/object.txt"
+        assert s3_url.url == url
+        assert s3_url.prefix == "example"
+        assert s3_url.filename == "object.txt"
 
     def test_key_with_query_string(self):
-        from aws.osml.data_intake.managers.s3_manager import S3Url
-
         url = "s3://my-bucket/path/to/object?param1=value1&param2=value2"
         s3_url = S3Url(url)
         expected_key = "path/to/object?param1=value1&param2=value2"
-        self.assertEqual(s3_url.key, expected_key)
+        assert s3_url.key == expected_key
 
 
-@mock_aws
-class TestS3Manager(unittest.TestCase):
-    """
-    A test suite for the S3Manager class in the AWS OSML data intake module.
+@pytest.fixture
+def s3_env():
+    """Set up the test environment for S3Manager tests."""
+    with mock_aws():
+        s3_client = boto3.resource("s3", region_name="us-east-1")
+        bucket_name = "output_bucket"
+        s3_client.meta.client.create_bucket(Bucket=bucket_name)
+        s3_manager = S3Manager(bucket_name)
+        yield s3_client, s3_manager, bucket_name
 
-    Tests file uploading and downloading functionality using a mocked AWS S3 environment.
-    """
 
-    def setUp(self):
-        """
-        Set up the test environment for S3Manager tests.
-        """
-        from aws.osml.data_intake.managers.s3_manager import S3Manager
+class TestS3Manager:
+    """A test suite for the S3Manager class in the AWS OSML data intake module."""
 
-        self.s3_client = boto3.resource("s3", region_name="us-east-1")
-        self.bucket_name = "output_bucket"
-        self.s3_client.meta.client.create_bucket(Bucket=self.bucket_name)
-        self.s3_manager = S3Manager(self.bucket_name)
-
-    def test_download_file(self):
+    def test_download_file(self, s3_env):
         """
         Test the download functionality of S3Manager.
 
         Ensures a file can be downloaded from S3 and is correctly placed in the local temporary directory.
         """
-        from aws.osml.data_intake.managers.s3_manager import S3Url
-
+        s3_client, s3_manager, _ = s3_env
         s3_url = S3Url("s3://output_bucket/test_download_file.txt")
-        self.s3_client.meta.client.put_object(Bucket=s3_url.bucket, Key=s3_url.key, Body=b"Hello world!")
-        file_path = self.s3_manager.download_file(s3_url)
+        s3_client.meta.client.put_object(Bucket=s3_url.bucket, Key=s3_url.key, Body=b"Hello world!")
+        file_path = s3_manager.download_file(s3_url)
 
         with open(file_path, "rb") as f:
             content = f.read()
-        self.assertEqual(content, b"Hello world!")
+        assert content == b"Hello world!"
 
-    def test_upload_file(self):
+    def test_upload_file(self, s3_env, tmp_path):
         """
         Test the upload functionality of S3Manager.
 
         Ensures a file can be uploaded to S3 and verifies the uploaded content matches the local file.
         """
-        file_path = "/tmp/test_upload_file.txt"
-        with open(file_path, "w") as f:
-            f.write("Upload me!")
+        s3_client, s3_manager, bucket_name = s3_env
+        file_path = tmp_path / "test_upload_file.txt"
+        file_path.write_text("Upload me!")
 
-        self.s3_manager.upload_file(file_path, "text file")
-        response = self.s3_client.meta.client.get_object(Bucket=self.bucket_name, Key="test_upload_file.txt")
+        s3_manager.upload_file(str(file_path), "text file")
+        response = s3_client.meta.client.get_object(Bucket=bucket_name, Key="test_upload_file.txt")
         data = response["Body"].read()
-        self.assertEqual(data.decode(), "Upload me!")
+        assert data.decode() == "Upload me!"
 
-    def test_download_file_client_error(self):
+    def test_download_file_client_error(self, s3_env):
         """
         Test error handling in download_file for non-existent buckets.
 
-        Verifies that a Exception is raised when attempting to download from a non-existent bucket.
+        Verifies that None is returned when attempting to download from a non-existent bucket.
         """
-        from aws.osml.data_intake.managers.s3_manager import S3Url
-
+        _, s3_manager, _ = s3_env
         s3_url = S3Url("s3://nonexistent_bucket/test_download_file.txt")
-        s3_path = self.s3_manager.download_file(s3_url)
-        self.assertEqual(None, s3_path)
+        s3_path = s3_manager.download_file(s3_url)
+        assert s3_path is None
 
-    @patch("logging.Logger.error")
-    def test_download_file_404_error(self, mock_error):
-        from aws.osml.data_intake.managers.s3_manager import S3Url
-
-        with patch("boto3.s3.transfer.S3Transfer.download_file") as download_file:
+    def test_download_file_404_error(self, s3_env):
+        _, s3_manager, _ = s3_env
+        with patch("logging.Logger.error") as mock_error, patch(
+            "boto3.s3.transfer.S3Transfer.download_file"
+        ) as download_file:
             download_file.side_effect = ClientError({"Error": {"Code": "404"}}, "unexpected")
 
             s3_url = S3Url("s3://my-bucket/my-key")
-            self.s3_manager.download_file(s3_url)
+            s3_manager.download_file(s3_url)
 
             mock_error.assert_called_with(
                 "S3 error: An error occurred (404) when calling the unexpected operation: Unknown The "
                 + f"{s3_url.bucket} bucket does not exist!"
             )
 
-    @patch("logging.Logger.error")
-    def test_download_file_403_error(self, mock_error):
-        from aws.osml.data_intake.managers.s3_manager import S3Url
-
-        with patch("boto3.s3.transfer.S3Transfer.download_file") as download_file:
+    def test_download_file_403_error(self, s3_env):
+        _, s3_manager, _ = s3_env
+        with patch("logging.Logger.error") as mock_error, patch(
+            "boto3.s3.transfer.S3Transfer.download_file"
+        ) as download_file:
             download_file.side_effect = ClientError({"Error": {"Code": "403"}}, "unexpected")
 
             s3_url = S3Url("s3://my-bucket/my-key")
-            self.s3_manager.download_file(s3_url)
+            s3_manager.download_file(s3_url)
 
             mock_error.assert_called_with(
                 "S3 error: An error occurred (403) when calling the unexpected operation: Unknown You"
@@ -134,28 +121,23 @@ class TestS3Manager(unittest.TestCase):
                 + f"{s3_url.bucket} bucket!"
             )
 
-    def test_download_file_exception_error(self):
-        from aws.osml.data_intake.managers.s3_manager import S3Url
-
+    def test_download_file_exception_error(self, s3_env):
+        _, s3_manager, _ = s3_env
         with patch("boto3.s3.transfer.S3Transfer.download_file") as download_file:
             download_file.side_effect = Exception("Unexpected")
 
             s3_url = S3Url("s3://my-bucket/my-key")
-            self.s3_manager.download_file(s3_url)
+            s3_manager.download_file(s3_url)
 
-    def test_upload_file_client_error(self):
+    def test_upload_file_client_error(self, s3_env, tmp_path):
         """
         Test error handling in upload_file for incorrect bucket permissions.
 
         Verifies that an S3UploadFailedError is raised when attempting to upload to a bucket with incorrect permissions.
         """
-        file_path = "/tmp/test_upload_file.txt"
-        with open(file_path, "w") as f:
-            f.write("Upload me!")
-        self.s3_manager.output_bucket = "non-exist-bucket"
-        with self.assertRaises(S3UploadFailedError):
-            self.s3_manager.upload_file(file_path, "text file")
-
-
-if __name__ == "__main__":
-    unittest.main()
+        _, s3_manager, _ = s3_env
+        file_path = tmp_path / "test_upload_file.txt"
+        file_path.write_text("Upload me!")
+        s3_manager.output_bucket = "non-exist-bucket"
+        with pytest.raises(S3UploadFailedError):
+            s3_manager.upload_file(str(file_path), "text file")

--- a/test/aws/osml/data_intake/test_bulk_processor.py
+++ b/test/aws/osml/data_intake/test_bulk_processor.py
@@ -1,40 +1,38 @@
-# Copyright 2024-2025 Amazon.com, Inc. or its affiliates.
+# Copyright 2024-2026 Amazon.com, Inc. or its affiliates.
 
 import json
 import os
-import unittest
 from unittest.mock import MagicMock, mock_open, patch
 
 import boto3
 import pytest
 from moto import mock_aws
 
+from aws.osml.data_intake.bulk_processor import BulkProcessor, process_manifest_file
+from aws.osml.data_intake.managers import S3Url
 
-@mock_aws
-class TestBulkProcessor(unittest.TestCase):
-    def setUp(self):
-        from aws.osml.data_intake.bulk_processor import BulkProcessor
 
-        self.test_bucket = "test-bucket"
-        self.failed_manifest_file = "./test/data/failed_images_manifest.json"
-        self.test_image = f"s3://{self.test_bucket}/small.tif"
-        self.aws_s3 = boto3.resource("s3", region_name="us-east-1")
-        self.aws_s3.meta.client.create_bucket(Bucket=self.test_bucket)
-        self.aws_s3.meta.client.upload_file("./test/data/small.tif", self.test_bucket, "small.tif")
-        self.aws_s3.meta.client.upload_file("./test/data/manifest.json", self.test_bucket, "manifest.json")
+@pytest.fixture
+def bulk_env():
+    """Set up the test environment for BulkProcessor tests."""
+    with mock_aws():
+        test_bucket = "test-bucket"
+        aws_s3 = boto3.resource("s3", region_name="us-east-1")
+        aws_s3.meta.client.create_bucket(Bucket=test_bucket)
+        aws_s3.meta.client.upload_file("./test/data/small.tif", test_bucket, "small.tif")
+        aws_s3.meta.client.upload_file("./test/data/manifest.json", test_bucket, "manifest.json")
 
-        self.s3_uri = os.environ["S3_URI"]
-        self.input_path = os.environ["S3_INPUT_PATH"]
-        self.output_path = os.environ["S3_OUTPUT_PATH"]
-        self.output_bucket = os.environ["S3_OUTPUT_BUCKET"]
-        self.stac_endpoint = os.environ["STAC_ENDPOINT"]
-        self.collection_id = os.environ["COLLECTION_ID"]
-        self.bulk_processor = BulkProcessor(
-            self.aws_s3, self.output_path, self.output_bucket, self.stac_endpoint, self.collection_id, self.input_path
-        )
+        s3_uri = os.environ["S3_URI"]
+        input_path = os.environ["S3_INPUT_PATH"]
+        output_path = os.environ["S3_OUTPUT_PATH"]
+        output_bucket = os.environ["S3_OUTPUT_BUCKET"]
+        stac_endpoint = os.environ["STAC_ENDPOINT"]
+        collection_id = os.environ["COLLECTION_ID"]
+        bulk_processor = BulkProcessor(aws_s3, output_path, output_bucket, stac_endpoint, collection_id, input_path)
 
-        self.error_details = {"image": self.test_image, "error": "TEST_ERROR", "internal_traceback": "TEST_TRACEBACK"}
-        self.stac_items = [
+        test_image = f"s3://{test_bucket}/small.tif"
+        error_details = {"image": test_image, "error": "TEST_ERROR", "internal_traceback": "TEST_TRACEBACK"}
+        stac_items = [
             {
                 "id": "123",
                 "type": "Feature",
@@ -49,77 +47,87 @@ class TestBulkProcessor(unittest.TestCase):
             }
         ]
 
-    def test_process_manifest_file(self):
-        from aws.osml.data_intake.bulk_processor import process_manifest_file
+        yield {
+            "aws_s3": aws_s3,
+            "bulk_processor": bulk_processor,
+            "test_bucket": test_bucket,
+            "test_image": test_image,
+            "s3_uri": s3_uri,
+            "input_path": input_path,
+            "error_details": error_details,
+            "stac_items": stac_items,
+        }
 
-        lst = process_manifest_file(self.aws_s3, self.input_path, self.s3_uri)
+
+class TestBulkProcessor:
+    def test_process_manifest_file(self, bulk_env):
+        lst = process_manifest_file(bulk_env["aws_s3"], bulk_env["input_path"], bulk_env["s3_uri"])
 
         assert len(lst) == 1
-        assert lst[0] == self.test_image
+        assert lst[0] == bulk_env["test_image"]
 
-    def test_generate_upload_files(self):
-        from aws.osml.data_intake.managers import S3Url
-
+    def test_generate_upload_files(self, bulk_env):
+        bulk_processor = bulk_env["bulk_processor"]
         mock_item_id = "mock_id"
 
-        image_data, s3_manager, ovr_file = self.bulk_processor.generate_upload_files(self.test_image, mock_item_id)
+        image_data, s3_manager, ovr_file = bulk_processor.generate_upload_files(bulk_env["test_image"], mock_item_id)
 
-        self.assertEqual(image_data.width, 3376)
-        self.assertEqual(image_data.height, 2576)
+        assert image_data.width == 3376
+        assert image_data.height == 2576
 
-        self.assertIsInstance(ovr_file, str)
+        assert isinstance(ovr_file, str)
 
-        s3_url = S3Url(self.test_image)
-        self.assertEqual(s3_manager.s3_url.bucket, s3_url.bucket)
-        self.assertEqual(s3_manager.s3_url.key, s3_url.key)
-        self.assertEqual(s3_manager.s3_url.url, s3_url.url)
-        self.assertEqual(s3_manager.output_bucket, f"s3://{self.test_bucket}")
+        s3_url = S3Url(bulk_env["test_image"])
+        assert s3_manager.s3_url.bucket == s3_url.bucket
+        assert s3_manager.s3_url.key == s3_url.key
+        assert s3_manager.s3_url.url == s3_url.url
+        assert s3_manager.output_bucket == f"s3://{bulk_env['test_bucket']}"
 
         # clean up empty folder
         remove_folder = f"./test/data/{mock_item_id}"
         if os.path.exists(remove_folder):
             os.removedirs(remove_folder)
 
-    def test_record_failed_image(self):
-        self.bulk_processor.record_failed_image(self.error_details)
-        with open(self.failed_manifest_file, "r") as f:
+    def test_record_failed_image(self, bulk_env, tmp_path):
+        bulk_processor = bulk_env["bulk_processor"]
+        failed_manifest_file = str(tmp_path / "failed_images_manifest.json")
+        bulk_processor.failed_manifest_path = failed_manifest_file
+
+        bulk_processor.record_failed_image(bulk_env["error_details"])
+        with open(failed_manifest_file, "r") as f:
             file_content = f.read()
 
-        self.assertIn(json.dumps(self.error_details), file_content)
-        if os.path.exists(self.failed_manifest_file):
-            os.remove(self.failed_manifest_file)
+        assert json.dumps(bulk_env["error_details"]) in file_content
 
-    @patch("logging.Logger.info")
-    @patch("stac_fastapi.opensearch.database_logic.DatabaseLogic.bulk_sync", new_callable=MagicMock)
-    def test_bulk_add_image(self, mock_bulk_item, mock_info):
-        mock_bulk_item.return_value.set_result(None)
-        mock_collection_name = "test-collection"
-        self.bulk_processor.submit_bulk_data_catalog(mock_collection_name, self.stac_items)  # stimulate bulk add
-        mock_info.assert_called_with(
-            f"Successfully bulk inserted {len(self.stac_items)} item(s) to the {mock_collection_name} collection!"
-        )
+    def test_bulk_add_image(self, bulk_env):
+        bulk_processor = bulk_env["bulk_processor"]
+        with patch("logging.Logger.info") as mock_info, patch(
+            "stac_fastapi.opensearch.database_logic.DatabaseLogic.bulk_sync", new_callable=MagicMock
+        ) as mock_bulk_item:
+            mock_bulk_item.return_value.set_result(None)
+            mock_collection_name = "test-collection"
+            bulk_processor.submit_bulk_data_catalog(mock_collection_name, bulk_env["stac_items"])
+            mock_info.assert_called_with(
+                f"Successfully bulk inserted {len(bulk_env['stac_items'])} item(s) to the {mock_collection_name} collection!"
+            )
 
-    @patch("logging.Logger.error")
-    @patch("stac_fastapi.opensearch.database_logic.DatabaseLogic.bulk_sync", new_callable=MagicMock)
-    def test_failed_bulk_add_image(self, mock_bulk_item, mock_info):
-        mock_bulk_item.side_effect = Exception("Unable to submit data catalog item...")
-        with pytest.raises(Exception):
-            self.bulk_processor.submit_bulk_data_catalog("test-collection", self.stac_items)  # stimulate bulk add
-            mock_info.assert_called_with("Unable to submit data catalog item...")
+    def test_failed_bulk_add_image(self, bulk_env):
+        bulk_processor = bulk_env["bulk_processor"]
+        with patch("logging.Logger.error") as mock_error, patch(
+            "stac_fastapi.opensearch.database_logic.DatabaseLogic.bulk_sync", new_callable=MagicMock
+        ) as mock_bulk_item:
+            mock_bulk_item.side_effect = Exception("Unable to submit data catalog item...")
+            with pytest.raises(Exception):
+                bulk_processor.submit_bulk_data_catalog("test-collection", bulk_env["stac_items"])
+            mock_error.assert_called_once()
 
-    @patch("builtins.open", new_callable=mock_open)
-    @patch("logging.Logger.error")
-    def test_record_failed_image_exception(self, mock_error, mock_open):
-        # Simulate an exception when opening the file
-        mock_open.side_effect = IOError("Failed to open file")
+    def test_record_failed_image_exception(self, bulk_env):
+        bulk_processor = bulk_env["bulk_processor"]
+        with patch("logging.Logger.error") as mock_error, patch("builtins.open", new_callable=mock_open) as mocked_open:
+            mocked_open.side_effect = IOError("Failed to open file")
 
-        self.bulk_processor.record_failed_image(self.error_details)
+            bulk_processor.record_failed_image(bulk_env["error_details"])
 
-        # Check that logging.error was called
-        mock_error.assert_called_with(
-            f"Failed to record failed image details in {self.failed_manifest_file}: Failed to open file"
-        )
-
-
-if __name__ == "__main__":
-    unittest.main()
+            mock_error.assert_called_with(
+                f"Failed to record failed image details in {bulk_processor.failed_manifest_path}: Failed to open file"
+            )

--- a/test/aws/osml/data_intake/test_ingest_processor.py
+++ b/test/aws/osml/data_intake/test_ingest_processor.py
@@ -1,12 +1,14 @@
-#  Copyright 2024-2025 Amazon.com, Inc. or its affiliates.
+#  Copyright 2024-2026 Amazon.com, Inc. or its affiliates.
 
 import json
-import unittest
 from unittest.mock import AsyncMock, patch
 
 import boto3
+import pytest
 from moto import mock_aws
 from stac_fastapi.types.stac import Item
+
+from aws.osml.data_intake.ingest_processor import handler
 
 mock_message = json.dumps(
     {
@@ -27,73 +29,78 @@ mock_message = json.dumps(
 )
 
 
-@mock_aws
-class TestIngestProcessor(unittest.TestCase):
+def sns_event():
     """
-    Test case class for validating the STAC ingestion Lambda functions.
+    Constructs a mock SNS event for testing.
+
+    Returns:
+        dict: A dictionary representing the SNS event with a predefined message.
     """
-
-    @staticmethod
-    def sns_event():
-        """
-        Constructs a mock SNS event for testing.
-
-        Returns:
-            dict: A dictionary representing the SNS event with a predefined message.
-        """
-        return {"Records": [{"Sns": {"Message": mock_message}}]}
-
-    def setUp(self):
-        """
-        Set up method to initialize required AWS resources before each test.
-        """
-        self.sns = boto3.client("sns", region_name="us-east-1")
-        self.sns.create_topic(Name="test-topic")
-
-        self.s3 = boto3.client("s3", region_name="us-east-1")
-        self.s3.create_bucket(Bucket="test-bucket")
-
-    @patch("stac_fastapi.opensearch.database_logic.DatabaseLogic.check_collection_exists", new_callable=AsyncMock)
-    @patch("stac_fastapi.opensearch.database_logic.DatabaseLogic.async_prep_create_item", new_callable=AsyncMock)
-    @patch("stac_fastapi.opensearch.database_logic.DatabaseLogic.create_item", new_callable=AsyncMock)
-    def test_handler_success(self, mock_create_item, mock_check_collection, mock_prep_item):
-        """
-        Test the handler function for a successful scenario.
-        """
-        from aws.osml.data_intake.ingest_processor import handler
-
-        # Set up async mock return values directly
-        mock_check_collection.return_value = None
-        mock_prep_item.return_value = Item(**json.loads(mock_message))
-        mock_create_item.return_value = None
-
-        event = self.sns_event()
-        response = handler(event, None)
-
-        self.assertEqual(response["statusCode"], 200)
-        self.assertIn("successfully", json.loads(response["body"]))
-
-    @patch("stac_fastapi.opensearch.database_logic.DatabaseLogic.check_collection_exists", new_callable=AsyncMock)
-    @patch("stac_fastapi.opensearch.database_logic.DatabaseLogic.async_prep_create_item", new_callable=AsyncMock)
-    @patch("stac_fastapi.opensearch.database_logic.DatabaseLogic.create_item", new_callable=AsyncMock)
-    def test_handler_failure(self, mock_create_item, mock_check_collection, mock_prep_item):
-        """
-        Test the handler function for a unsuccessful scenario.
-        """
-        from aws.osml.data_intake.ingest_processor import handler
-
-        # Set up async mock return values directly
-        mock_check_collection.return_value = None
-        mock_prep_item.return_value = Item(**json.loads(mock_message))
-
-        mock_create_item.side_effect = Exception("Database error")
-
-        event = self.sns_event()
-        response = handler(event, None)
-
-        self.assertEqual(response["statusCode"], 500)
-        self.assertIn("Database error", json.loads(response["body"])["message"])
+    return {"Records": [{"Sns": {"Message": mock_message}}]}
 
 
-if __name__ == "__main__":
-    unittest.main()
+@pytest.fixture
+def ingest_env():
+    """Set up required AWS resources before each test."""
+    with mock_aws():
+        sns = boto3.client("sns", region_name="us-east-1")
+        sns.create_topic(Name="test-topic")
+
+        s3 = boto3.client("s3", region_name="us-east-1")
+        s3.create_bucket(Bucket="test-bucket")
+
+        yield
+
+
+class TestIngestProcessor:
+    """Test case class for validating the STAC ingestion Lambda functions."""
+
+    def test_handler_success(self, ingest_env):
+        """Test the handler function for a successful scenario."""
+        with (
+            patch(
+                "stac_fastapi.opensearch.database_logic.DatabaseLogic.check_collection_exists",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "stac_fastapi.opensearch.database_logic.DatabaseLogic.async_prep_create_item",
+                new_callable=AsyncMock,
+                return_value=Item(**json.loads(mock_message)),
+            ),
+            patch(
+                "stac_fastapi.opensearch.database_logic.DatabaseLogic.create_item",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+        ):
+            event = sns_event()
+            response = handler(event, None)
+
+            assert response["statusCode"] == 200
+            assert "successfully" in json.loads(response["body"])
+
+    def test_handler_failure(self, ingest_env):
+        """Test the handler function for an unsuccessful scenario."""
+        with (
+            patch(
+                "stac_fastapi.opensearch.database_logic.DatabaseLogic.check_collection_exists",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "stac_fastapi.opensearch.database_logic.DatabaseLogic.async_prep_create_item",
+                new_callable=AsyncMock,
+                return_value=Item(**json.loads(mock_message)),
+            ),
+            patch(
+                "stac_fastapi.opensearch.database_logic.DatabaseLogic.create_item",
+                new_callable=AsyncMock,
+                side_effect=Exception("Database error"),
+            ),
+        ):
+            event = sns_event()
+            response = handler(event, None)
+
+            assert response["statusCode"] == 500
+            assert "Database error" in json.loads(response["body"])["message"]

--- a/test/aws/osml/data_intake/utils/test_app_config.py
+++ b/test/aws/osml/data_intake/utils/test_app_config.py
@@ -1,12 +1,10 @@
-#  Copyright 2024 Amazon.com, Inc. or its affiliates.
+#  Copyright 2024-2026 Amazon.com, Inc. or its affiliates.
 
-import unittest
+from aws.osml.data_intake.utils.app_config import get_minimal_collection_dict
 
 
-class TestLambdaLogger(unittest.TestCase):
+class TestAppConfig:
     def test_minimal_collection(self):
-        from aws.osml.data_intake.utils.app_config import get_minimal_collection_dict
-
         mock_collection_id = "test-collection"
         expected_minimal_collection = {
             "type": "Collection",


### PR DESCRIPTION
**Issue #, if available:** n/a

## Summary
- Migrate all 6 unittest-based test files to idiomatic pytest, removing all `unittest.TestCase` usage from the test suite
- Create shared `conftest.py` with reusable AWS mock fixtures
- Fix unreachable assertion in `test_failed_bulk_add_image` and incorrect class name `TestLambdaLogger` in `test_app_config.py`
-  No test logic removed or test count changed
- No `import unittest` or `unittest.TestCase` references remain in any test file

## Changes

**New file:**
- `test/aws/osml/data_intake/conftest.py` — shared `mock_s3`, `mock_sns`, and `mock_aws_services` fixtures

**Migrated files (6):**

| File | Key changes |
|---|---|
| `utils/test_app_config.py` | Fixed class name `TestLambdaLogger` → `TestAppConfig`, dropped `unittest.TestCase` |
| `utils/test_logger.py` | Converted `self.assert*` → bare `assert`, replaced `@patch` decorators with context managers, moved imports to module level |
| `managers/test_sns_manager.py` | Converted `setUp` → `sns_manager` fixture, `self.assertRaises` → `pytest.raises` |
| `managers/test_s3_manager.py` | Converted `setUp` → `s3_env` fixture, replaced manual `/tmp` files with `tmp_path`, replaced `@patch` decorators with context managers |
| `test_ingest_processor.py` | Converted `setUp` → `ingest_env` fixture, replaced stacked `@patch` decorators with parenthesized `with` context managers |
| `test_bulk_processor.py` | Converted `setUp` → `bulk_env` fixture, used `tmp_path` for `test_record_failed_image`, fixed `test_failed_bulk_add_image` where mock assertion was unreachable inside `pytest.raises` block |

## Bug fixes
- `test_app_config.py`: class was named `TestLambdaLogger` instead of `TestAppConfig`
- `test_bulk_processor.py`: `mock_info.assert_called_with(...)` in `test_failed_bulk_add_image` was placed after the raising call inside `pytest.raises`, so it never executed — moved outside the block

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
